### PR TITLE
Clean up: ephys stimulus

### DIFF
--- a/schemas/stimulus/ephysStimulus.schema.tpl.json
+++ b/schemas/stimulus/ephysStimulus.schema.tpl.json
@@ -2,8 +2,8 @@
   "_type": "https://openminds.ebrains.eu/stimulation/EphysStimulus",
   "_extends": "/stimulus/stimulus.schema.tpl.json",
   "properties": {
-    "stimulusType": {
-      "_instruction": "Add the type of the electrical stimulus.",
+    "type": {
+      "_instruction": "Add the type that describe this electrical stimulus.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/ElectricalStimulusType"
       ]


### PR DESCRIPTION
MINOR changes:
- improved instructions
- renamed `stimulusType` to `type` to reduce list of properties & because of new convention to use type when the additional information is not adding any other meaning than imposed by schema already 

MAJOR changes:
none

SPECIAL ATTENTION:
none