### PR TITLE
Clean up: stimulation activity

### DIFF
--- a/schemas/activity/stimulationActivity.schema.tpl.json
+++ b/schemas/activity/stimulationActivity.schema.tpl.json
@@ -2,7 +2,7 @@
   "_type": "https://openminds.ebrains.eu/stimulation/StimulationActivity",
   "_extends": "/core/schemas/research/experimentalActivity.schema.tpl.json",
   "required": [
-    "stimulusType"
+    "stimulus"
   ],
   "properties": {
     "input": {
@@ -35,13 +35,13 @@
         "https://openminds.ebrains.eu/core/Setup"
       ]
     },
-    "stimulusType": {
+    "stimulus": {
       "type": "array",
       "minItems": 1,     
       "uniqueItems": true,
-      "_instruction": "Add all stimulus types used during this activity.",
+      "_instruction": "Add all stimuli used during this activity.",
       "_linkedCategories": [
-        "stimulusType"
+        "stimulus"
       ]
     }
   }

--- a/schemas/activity/stimulationActivity.schema.tpl.json
+++ b/schemas/activity/stimulationActivity.schema.tpl.json
@@ -2,46 +2,47 @@
   "_type": "https://openminds.ebrains.eu/stimulation/StimulationActivity",
   "_extends": "/core/schemas/research/experimentalActivity.schema.tpl.json",
   "required": [
-    "stimulus"
+    "stimulusType"
   ],
   "properties": {
     "input": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all specimens that were stimulated within this stimulation activity.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
-        "https://openminds.ebrains.eu/core/TissueSampleState",
+      "_instruction": "Add all states of the specimen(s) that are being stimulated during this activity.",
+      "_linkedTypes": [        
         "https://openminds.ebrains.eu/core/SubjectGroupState",
-        "https://openminds.ebrains.eu/core/SubjectState"
+        "https://openminds.ebrains.eu/core/SubjectState",
+        "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
+        "https://openminds.ebrains.eu/core/TissueSampleState"
       ]
     },
     "output": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all specimens that were resulted by this stimulation activity.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
-        "https://openminds.ebrains.eu/core/TissueSampleState",
+      "_instruction": "Add all states of the specimen(s) that were stimulated as a result of this activity.",
+      "_linkedTypes": [       
         "https://openminds.ebrains.eu/core/SubjectGroupState",
-        "https://openminds.ebrains.eu/core/SubjectState"
+        "https://openminds.ebrains.eu/core/SubjectState",
+        "https://openminds.ebrains.eu/core/TissueSampleCollectionState",
+        "https://openminds.ebrains.eu/core/TissueSampleState"
       ]
     },
     "setup": {
-      "_instruction": "Add the setup used for this stimulation.",
+      "_instruction": "Add the setup used during this stimulation activity.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/Setup"
       ]
     },
-    "stimulus": {
+    "stimulusType": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 1,     
+      "uniqueItems": true,
+      "_instruction": "Add all stimulus types used during this activity.",
       "_linkedCategories": [
-        "stimulus"
-      ],
-      "_instruction": "Add the stimulus used in this activity."
+        "stimulusType"
+      ]
     }
   }
 }


### PR DESCRIPTION
MINOR changes:
- improved instruction
- establish correct order within property
- replaced category `stimulus` with `stimulusType` because category `stimulus` does not exist
- renamed property `stimulus` to `stimulusType` according to change in its links 

MAJOR changes:
none

SPECIAL ATTENTION:
- added `uniqueItems` to `stimulusType` because it seems pointless to state the same one several times within one activity