### PR TITLE
Extension non-resolvable

### DIFF
--- a/schemas/stimulus/ephysStimulus.schema.tpl.json
+++ b/schemas/stimulus/ephysStimulus.schema.tpl.json
@@ -1,6 +1,6 @@
 {
   "_type": "https://openminds.ebrains.eu/stimulation/EphysStimulus",
-  "_extends": "/stimulus/stimulus.schema.tpl.json",
+  "_extends": "stimulus/stimulus.schema.tpl.json",
   "properties": {
     "type": {
       "_instruction": "Add the type that describe this electrical stimulus.",


### PR DESCRIPTION
The extension is supposed to be relative because it references an extension in the same module. otherwise it's non-resolvable