### PR TITLE
Link StimulationActivity to the files generated by the activity

### DIFF
--- a/schemas/activity/stimulationActivity.schema.tpl.json
+++ b/schemas/activity/stimulationActivity.schema.tpl.json
@@ -21,8 +21,10 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add all states of the specimen(s) that were stimulated as a result of this activity.",
-      "_linkedTypes": [       
+      "_instruction": "Add all states of the specimen(s) that were stimulated as a result of this activity, and all files or file bundles generated.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/core/File",
+        "https://openminds.ebrains.eu/core/FileBundle",
         "https://openminds.ebrains.eu/core/SubjectGroupState",
         "https://openminds.ebrains.eu/core/SubjectState",
         "https://openminds.ebrains.eu/core/TissueSampleCollectionState",


### PR DESCRIPTION
At present it is not possible to link a File to the StimulationActivity that was used to generate that file. This fixes that missing connection.